### PR TITLE
fix para que no hayan problemas de caché al entrar al deploy

### DIFF
--- a/OmniMonitor/Server/Program.cs
+++ b/OmniMonitor/Server/Program.cs
@@ -95,7 +95,15 @@ if (configuration.GetValue<bool>("EnableHttpsRedirection"))
 app.UseHttpsRedirection();
 
 app.UseBlazorFrameworkFiles();
-app.UseStaticFiles();
+app.UseStaticFiles(new StaticFileOptions
+{
+    OnPrepareResponse = ctx =>
+    {
+        ctx.Context.Response.Headers.Append("Cache-Control", "no-cache, no-store, must-revalidate");
+        ctx.Context.Response.Headers.Append("Pragma", "no-cache");
+        ctx.Context.Response.Headers.Append("Expires", "0");
+    }
+});
 
 app.UseRouting();
 app.UseCors(corsPolicy);


### PR DESCRIPTION
## Descripción

Se agrega configuración de headers Cache-Control en Program.cs para evitar que Azure App Service y los navegadores cacheen archivos estáticos (JS, CSS, imágenes).
Con este cambio, cada deploy mostrará siempre la última versión de la aplicación sin necesidad de limpiar caché manualmente.

## Checklist

- [ Sí] Código compilado sin errores
- [ ] Tests locales ejecutados y aprobados
- [ ] Commit y branch nombrados con ticket correspondiente
- [ ] PR revisado y aprobado por los reviewers necesarios
