### PR TITLE
Arreglos AppBar y sideBar

### DIFF
--- a/OmniMonitor/Client/Resources/SharedResource.en.resx
+++ b/OmniMonitor/Client/Resources/SharedResource.en.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -105,6 +105,11 @@
       </xsd:complexType>
     </xsd:element>
   </xsd:schema>
+  
+  <!-- AppBar -->
+  <data name="Logout" xml:space="preserve">
+    <value>Logout</value>
+  </data>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -134,5 +139,8 @@
   </data>
   <data name="VisualizationsTitle" xml:space="preserve">
     <value>Visualizations</value>
+  </data>
+  <data name="QuickViewTitle" xml:space="preserve">
+    <value>Quick View</value>
   </data>
 </root>

--- a/OmniMonitor/Client/Resources/SharedResource.es.resx
+++ b/OmniMonitor/Client/Resources/SharedResource.es.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -105,6 +105,11 @@
       </xsd:complexType>
     </xsd:element>
   </xsd:schema>
+  
+  <!-- AppBar -->
+  <data name="Logout" xml:space="preserve">
+    <value>Cerrar Sesión</value>
+  </data>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -134,5 +139,8 @@
   </data>
   <data name="VisualizationsTitle" xml:space="preserve">
     <value>Visualizaciones</value>
+  </data>
+  <data name="QuickViewTitle" xml:space="preserve">
+    <value>Visualización Rápida</value>
   </data>
 </root>

--- a/OmniMonitor/Client/Shared/AppBar.razor
+++ b/OmniMonitor/Client/Shared/AppBar.razor
@@ -1,6 +1,8 @@
 @using MudBlazor
 @inject NavigationManager Navigation
 @inject AuthenticationStateProvider AuthStateProvider
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<SharedResource> SharedLocalizer
 
 
 <div class="appbar-container">
@@ -11,7 +13,7 @@
             </Authorized>
         </AuthorizeView>
         <MudNavLink OnClick="@(() => Navigation.NavigateTo("/dashboards"))" Class="logo-link">
-            <div class="logo-container">
+            <div class="logo-container" >
                 <MudImage Src="LogoSonda.jpg" Alt="LogoS" Style="width:40px; height:40px;" Class="rounded-lg logo-image" />
                 <MudText Typo="Typo.h6" Class="logo-text">OmniMonitor</MudText>
             </div>
@@ -25,7 +27,7 @@
 
         <AuthorizeView>
             <Authorized>
-                <MudMenu Direction="Direction.Left" OffsetX="true" Dense="true">
+                <MudMenu Direction="Direction.Bottom" AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight" Dense="true">
                     <ActivatorContent>
                         <MudButton Variant="Variant.Text" Class="user-selector">
                             <MudIcon Icon="@Icons.Material.Filled.AccountCircle" Class="icon-account" />
@@ -35,7 +37,7 @@
                     <ChildContent>
                         <MudMenuItem OnClick="Logout">
                             <MudIcon Icon="@Icons.Material.Filled.Login" Class="mr-2" />
-                            <span>Cerrar Sesion</span>
+                            <span>@SharedLocalizer["Logout"]</span>
                         </MudMenuItem>
                     </ChildContent>
                 </MudMenu>

--- a/OmniMonitor/Client/Shared/AppBar.razor.css
+++ b/OmniMonitor/Client/Shared/AppBar.razor.css
@@ -24,7 +24,8 @@
 }
 
 ::deep .logo-link {
-    display: inline-block;
+    display: flex;
+    align-items: center;
     height: 100%;
     text-decoration: none;
     max-width: 210px;
@@ -66,7 +67,7 @@
 ::deep .user-selector {
     display: flex;
     align-items: center;
-    gap: 2px; /* controla la separación exacta entre los dos íconos */
+    gap: 2px;
     color: var(--text-secondary) !important;
     text-transform: none;
     font-weight: 500;
@@ -87,4 +88,32 @@
 
 ::deep .user-selector:hover .mud-icon-root {
     color: var(--text-primary) !important;
+}
+
+/* --- CÓDIGO PARA OCULTAR TEXTO EN MOVILES --- */
+@media (max-width: 599.98px) {
+    ::deep .logo-text {
+        display: none;
+    }
+}
+
+/* --- AJUSTES FINOS PARA MOVILES MUY ESTRECHOS --- */
+@media (max-width: 390px) {
+    /* Reduce el padding de la barra al mínimo */
+    .appbar-container ::deep .mud-appbar {
+        padding: 0 2px;
+    }
+
+    /* Elimina el ancho mínimo y reduce el padding de los botones */
+    ::deep .language-selector,
+    ::deep .user-selector {
+        min-width: 0;
+        padding: 0 2px;
+    }
+
+    /* Reduce un poco más el ícono de usuario si es necesario */
+    ::deep .user-selector .mud-icon-root {
+        font-size: 30px !important;
+    }
+
 }

--- a/OmniMonitor/Client/Shared/LanguageSelector.razor
+++ b/OmniMonitor/Client/Shared/LanguageSelector.razor
@@ -5,8 +5,7 @@
 @inject NavigationManager NavigationManager
 @inject ILocalStorageService LocalStorage
 
-<MudMenu Direction="Direction.Left" OffsetX="true" Dense="true">
-    <ActivatorContent>
+<MudMenu Direction="Direction.Bottom" AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight" Dense="true">    <ActivatorContent>
         <MudButton Variant="Variant.Text" EndIcon="@Icons.Material.Filled.ArrowDropDown" Class="language-selector">
             @(CurrentCulture?.TwoLetterISOLanguageName.ToUpper())
         </MudButton>

--- a/OmniMonitor/Client/Shared/NavMenu.razor
+++ b/OmniMonitor/Client/Shared/NavMenu.razor
@@ -39,7 +39,7 @@
         <MudNavLink Href="/Visualizacion-rapida" Icon=@Icons.Material.Filled.TrendingUp>
             @if (_drawerOpen)
             {
-                <span class="ml-2">Visualizacion Rapida</span>
+                <span class="ml-2">@SharedLocalizer["QuickViewTitle"]</span>
             }
         </MudNavLink>
               


### PR DESCRIPTION
## Descripción

Se aplica cambio de lenguaje a lo que le faltaba al navMenu y a cerrar sesión de la appbar, se corrige centrado de elementos de la appbar como el logo con el titulo omnimonitor y los menús de cerrar sesión y cambiar el lenguaje. Ahora se puede ver todo para dispositivos móviles, se oculta el titulo omnimonitor en móvil y se pueden ver los demás iconos. 

## Ticket asociado

Scrum 71-Fix:Sidebar
## Cómo probar


## Checklist

- [ ] Código compilado sin errores
- [ ] Tests locales ejecutados y aprobados
- [ ] Commit y branch nombrados con ticket correspondiente
- [ ] PR revisado y aprobado por los reviewers necesarios
